### PR TITLE
test: use `c8 --100` instead of a `"c8"` key in package.json for configuration

### DIFF
--- a/packages/auth-token/package.json
+++ b/packages/auth-token/package.json
@@ -27,14 +27,7 @@
   },
   "scripts": {
     "test": "npm run test:code && npm run test:types",
-    "test:code": "c8 ava test",
+    "test:code": "c8 --100 ava test",
     "test:types": "tsd"
-  },
-  "c8": {
-    "check-coverage": true,
-    "lines": 100,
-    "functions": 100,
-    "branches": 100,
-    "statements": 100
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run test:code && npm run test:types",
-    "test:code": "c8 ava test",
+    "test:code": "c8 --100 ava test",
     "test:types": "tsd"
   },
   "dependencies": {
@@ -34,12 +34,5 @@
     "@octokit-next/types": "0.0.0-development",
     "before-after-hook": "^3.0.2",
     "universal-user-agent": "^7.0.1"
-  },
-  "c8": {
-    "check-coverage": true,
-    "lines": 10,
-    "functions": 10,
-    "branches": 10,
-    "statements": 10
   }
 }

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run test:code && npm run test:types",
-    "test:code": "c8 ava test",
+    "test:code": "c8 --100 ava test",
     "test:types": "tsd"
   },
   "dependencies": {
@@ -31,12 +31,5 @@
     "is-plain-obj": "^4.0.0",
     "type-fest": "^3.0.0",
     "universal-user-agent": "^7.0.0"
-  },
-  "c8": {
-    "check-coverage": true,
-    "lines": 100,
-    "functions": 100,
-    "branches": 100,
-    "statements": 100
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -28,14 +28,7 @@
   },
   "scripts": {
     "test": "npm run test:code && npm run test:types",
-    "test:code": "c8 ava test",
+    "test:code": "c8 --100 ava test",
     "test:types": "tsd"
-  },
-  "c8": {
-    "check-coverage": true,
-    "lines": 100,
-    "functions": 100,
-    "branches": 100,
-    "statements": 100
   }
 }

--- a/packages/request-error/package.json
+++ b/packages/request-error/package.json
@@ -23,17 +23,10 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run test:code && npm run test:types",
-    "test:code": "c8 ava test",
+    "test:code": "c8 --100 ava test",
     "test:types": "tsd"
   },
   "dependencies": {
     "@octokit-next/types": "0.0.0-development"
-  },
-  "c8": {
-    "check-coverage": true,
-    "lines": 100,
-    "functions": 100,
-    "branches": 100,
-    "statements": 100
   }
 }

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run test:code && npm run test:types",
-    "test:code": "c8 ava test",
+    "test:code": "c8 --100 ava test",
     "test:types": "tsd"
   },
   "dependencies": {
@@ -34,12 +34,5 @@
   },
   "devDependencies": {
     "string-to-arraybuffer": "^1.0.2"
-  },
-  "c8": {
-    "check-coverage": true,
-    "lines": 100,
-    "functions": 100,
-    "branches": 100,
-    "statements": 100
   }
 }


### PR DESCRIPTION
closes #77