### PR TITLE
docs(readme): fix typo in dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A list of breaking changes compared to latest `@octokit/*` modules
   const octokit = new Octokit({ request: { fetch } });
   ```
 
-  For the static `@ocotkit-next/request` method you can do this
+  For the static `@octokit-next/request` method you can do this
 
   ```js
   import { request } from "@octokit-next/request";


### PR DESCRIPTION
not that big of a deal, but was curious about this package and noticed the typo. I checked, and it's present nowhere else in the repo as far as I can tell.