### PR TITLE
ci: stop testing against NodeJS v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm test
-  deno: # deno test
+  deno:
+    # deno test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=16.5.0",
+    "node": ">= 20",
     "npm": ">=7.17.0"
   },
   "publishConfig": {


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v18